### PR TITLE
[Fix] #17 - CustomBottomButton의 Bottom Constraints 수정

### DIFF
--- a/TeamProject/TeamProject/Presentation/Common/UIComponent/CustomBottomButton.swift
+++ b/TeamProject/TeamProject/Presentation/Common/UIComponent/CustomBottomButton.swift
@@ -49,14 +49,16 @@ class CustomBottomButton: BaseView {
         leftButtonView.addSubviews(leftButtonTitleLabel, leftButtonSubTitleLabel)
         
         leftButtonView.snp.makeConstraints {
-            $0.top.leading.bottom.equalToSuperview()
+            $0.top.leading.equalToSuperview()
+            $0.bottom.equalTo(safeAreaLayoutGuide.snp.bottom)
             $0.leading.equalToSuperview()
             $0.height.equalTo(SizeLiterals.Screen.screenHeight * 83 / 874)
             $0.width.equalTo(SizeLiterals.Screen.screenWidth * 260 / 402)
         }
  
         rightButton.snp.makeConstraints {
-            $0.top.trailing.bottom.equalToSuperview()
+            $0.top.trailing.equalToSuperview()
+            $0.bottom.equalTo(safeAreaLayoutGuide.snp.bottom)
             $0.leading.equalTo(leftButtonView.snp.trailing)
             $0.height.equalTo(SizeLiterals.Screen.screenHeight * 83 / 874)
             $0.width.equalTo(SizeLiterals.Screen.screenWidth * 142 / 402)


### PR DESCRIPTION
## 💭 작업 배경
- CustomBBottomButton의 하단 Layout설정 수정

## 🌤️ PR POINT
### 변경 전
``` swift
     leftButtonView.snp.makeConstraints {
            $0.top.leading.bottom.equalToSuperview()
            ...
     }

        rightButton.snp.makeConstraints {
            $0.top.trailing.bottom.equalToSuperview()
            ...
        }
```


### 변경 후
``` swift
     leftButtonView.snp.makeConstraints {
            $0.top.leading.equalToSuperview()
            $0.bottom.equalTo(safeAreaLayoutGuide.snp.bottom)
            ...
     }

        rightButton.snp.makeConstraints {
            $0.top.trailing.equalToSuperview()
            $0.bottom.equalTo(safeAreaLayoutGuide.snp.bottom)
            ...
        }
```

## 📸 스크린샷

|    기기    |   스크린샷(변경전)   |   스크린샷(변경후)   |
| :-------------: | :----------: |:----------: |
| 16pro | <img src = "https://github.com/user-attachments/assets/d5369523-cfb9-4159-864b-c77683b1506b" width ="250">| <img src = "https://github.com/user-attachments/assets/911dbfb0-3b2f-421e-a992-51e9d87ab4e8" width ="250">|
| SE3 | <img src = "https://github.com/user-attachments/assets/12a94d50-3955-4833-8a23-dfb764fa9aa0" width ="250">| <img src = "https://github.com/user-attachments/assets/a5c52721-47c7-48e7-ad83-88c1d784689a" width ="250">|

SE3은 기기 특성상 SafeArea와 하단 SuperView는 동일하지만, 이후 모델들 같은 경우에는 인디케이터바의 영역을 고려해서 SafeAreaBar로 하단 제약을 변경하는걸 건의합니다. 

저희 Figma 디자인에도 이와 같이 적용되어 있습니다.

<img width="174" alt="Image" src="https://github.com/user-attachments/assets/cd9bd628-4017-4751-b069-04f6e91df5fc" />

## 🌈 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #17