### PR TITLE
[Feat] #26 PayModel 아이콘 다크모드 수정

### DIFF
--- a/TeamProject/TeamProject/Presentation/Pay/View/DeleteButton.swift
+++ b/TeamProject/TeamProject/Presentation/Pay/View/DeleteButton.swift
@@ -11,15 +11,17 @@ import SnapKit
 import Then
 
 class DeleteButton: UIButton {
-    
+
     // MARK: - UI Components
 
     private let deleteImage = UIImageView().then {
-//        $0.image = ImageLiterals.iCon.trash_black_ic
-        // MARK: 테스트용
-        $0.image = UIImage(systemName: "trash")
-        $0.tintColor = .black000
-        
+        $0.image = {
+            if UITraitCollection.current.userInterfaceStyle == .light {
+                return ImageLiterals.iCon.trash_black_ic
+            } else {
+                return ImageLiterals.iCon.trash_white_ic
+            }
+        }()
     }
 
     private let detailTextLabel = UILabel().then {
@@ -33,34 +35,50 @@ class DeleteButton: UIButton {
         }
         $0.font = .fontGuide(.payModalDeleteLabel)
     }
-    
+
+    // MARK: - Override
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         setStyles()
         setLayout()
     }
-    
+
+    // 화면 모드 변환 탐지
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        // 이전과 현재 모드가 다를 때만 이미지 갱신
+        if previousTraitCollection?.userInterfaceStyle != traitCollection.userInterfaceStyle {
+            deleteImage.image = traitCollection.userInterfaceStyle == .light
+                ? ImageLiterals.iCon.trash_black_ic
+            : ImageLiterals.iCon.trash_white_ic
+        }
+    }
+
+    // MARK: - Style Helper
+
     private func setStyles() {
         self.backgroundColor = .clear
     }
-    
+
     // MARK: - Layout Helper
-    
+
     private func setLayout() {
         addSubviews(deleteImage, detailTextLabel)
-        
+
         deleteImage.snp.makeConstraints {
             $0.top.leading.bottom.equalToSuperview()
             $0.height.equalTo(SizeLiterals.Screen.screenHeight * 25 / 874)
             $0.width.equalTo(SizeLiterals.Screen.screenWidth * 20 / 402)
         }
-        
+
         detailTextLabel.snp.makeConstraints {
             $0.centerY.equalTo(deleteImage.snp.centerY)
             $0.trailing.equalToSuperview()
         }
     }
-    
+
     required init(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/TeamProject/TeamProject/Presentation/Pay/View/ShoppingItemEmptyView.swift
+++ b/TeamProject/TeamProject/Presentation/Pay/View/ShoppingItemEmptyView.swift
@@ -1,0 +1,53 @@
+//
+//  ShoppingItemEmptyView.swift
+//  TeamProject
+//
+//  Created by yimkeul on 4/10/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+class ShoppingItemEmptyView: BaseView {
+    
+    // MARK: - UI Components
+    
+    private let titleLabel = UILabel().then {
+        $0.text = "장바구니에 담은 상품이 없습니다."
+        $0.textAlignment = .center
+        $0.font = .fontGuide(.payModalEmptyLabel)
+        $0.textColor = .gray400
+    }
+    
+    private let appleLogoImageView = UIImageView().then {
+        $0.contentMode = .scaleAspectFit
+        $0.image = ImageLiterals.iCon.apple_ic
+    }
+    
+    
+    //MARK: Style Helper
+    
+    override func setStyles() {
+        backgroundColor = .clear
+    }
+    
+    // MARK: Layout Helper
+    
+    override func setLayout() {
+        addSubviews(appleLogoImageView, titleLabel)
+        
+        appleLogoImageView.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.centerX.equalToSuperview()
+            $0.height.equalTo(SizeLiterals.Screen.screenHeight * 100 / 874)
+            $0.width.equalTo(SizeLiterals.Screen.screenWidth * 100 / 402)
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.top.equalTo(appleLogoImageView.snp.bottom).offset(22)
+            $0.centerX.equalToSuperview()
+        }
+    }
+}

--- a/TeamProject/TeamProject/Presentation/Pay/View/ShoppingItemView.swift
+++ b/TeamProject/TeamProject/Presentation/Pay/View/ShoppingItemView.swift
@@ -69,6 +69,7 @@ class ShoppingItemView: BaseView {
         $0.value = 1
     }
     
+    // MARK: - Style Helper
     
     override func setStyles() {
         backgroundColor = .clear

--- a/TeamProject/TeamProject/Presentation/Pay/ViewController/PayModalViewController.swift
+++ b/TeamProject/TeamProject/Presentation/Pay/ViewController/PayModalViewController.swift
@@ -41,8 +41,12 @@ class PayModalViewController: BaseViewController {
 
     private let deleteButton = DeleteButton()
     private let popButton = UIButton().then {
-//        $0.setImage(ImageLiterals.iCon.close_button_lightMode_ic, for: .normal)
-        $0.setImage(UIImage(systemName: "xmark.circle"), for: .normal)
+        $0.setImage(
+            UITraitCollection.current.userInterfaceStyle == .light ?
+            ImageLiterals.iCon.close_button_lightMode_ic:
+                ImageLiterals.iCon.close_button_darkMode_ic,
+            for: .normal
+        )
     }
 
     private let scrollView = UIScrollView()
@@ -55,7 +59,7 @@ class PayModalViewController: BaseViewController {
     }
 
     private let bottomButtonView = CustomBottomButton()
-    
+
     // TODO: 따로 View로 생성하거나 이미지 추가로 넣는 방법 고려
     private let emptyStateView = UILabel().then {
         $0.text = "장바구니에 담은 상품이 없습니다."
@@ -71,6 +75,19 @@ class PayModalViewController: BaseViewController {
         setBottomButton()
         setAddTarget()
         configureShoppingItems()
+    }
+
+    // 화면 모드 변환 탐지
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        // 이전과 현재 모드가 다를 때만 이미지 갱신
+        if previousTraitCollection?.userInterfaceStyle != traitCollection.userInterfaceStyle {
+            popButton.setImage(traitCollection.userInterfaceStyle == .light ?
+                ImageLiterals.iCon.close_button_lightMode_ic :
+                ImageLiterals.iCon.close_button_darkMode_ic
+                , for: .normal)
+        }
     }
 
     override func setStyles() {
@@ -149,7 +166,7 @@ class PayModalViewController: BaseViewController {
         }
         updateEmptyStateView()
     }
-    
+
     private func updateEmptyStateView() {
         emptyStateView.isHidden = !shoppingItemViews.isEmpty
         scrollView.isHidden = shoppingItemViews.isEmpty

--- a/TeamProject/TeamProject/Presentation/Pay/ViewController/PayModalViewController.swift
+++ b/TeamProject/TeamProject/Presentation/Pay/ViewController/PayModalViewController.swift
@@ -40,6 +40,7 @@ class PayModalViewController: BaseViewController {
     // MARK: - UI Components
 
     private let deleteButton = DeleteButton()
+    
     private let popButton = UIButton().then {
         $0.setImage(
             UITraitCollection.current.userInterfaceStyle == .light ?
@@ -142,6 +143,8 @@ class PayModalViewController: BaseViewController {
         popButton.addTarget(self, action: #selector(popModal), for: .touchUpInside)
     }
 
+    
+    // TODO: 수정해야함. 가격 부분을 CoreData에서 받아온걸 계산해서 넣어야함.
     func setBottomButton() {
         bottomButtonView.configure("₩190,000", "결제하기")
     }
@@ -226,6 +229,7 @@ class PayModalViewController: BaseViewController {
 
     // MARK: - @objc Methods
 
+    // TODO: 계산식 들어가야함.
     @objc
     private func stepperValueChanged(_ sender: UIStepper) {
         guard let index = shoppingItemViews.firstIndex(where: {

--- a/TeamProject/TeamProject/Presentation/Pay/ViewController/PayModalViewController.swift
+++ b/TeamProject/TeamProject/Presentation/Pay/ViewController/PayModalViewController.swift
@@ -61,14 +61,7 @@ class PayModalViewController: BaseViewController {
     private let bottomButtonView = CustomBottomButton()
 
     // TODO: 따로 View로 생성하거나 이미지 추가로 넣는 방법 고려
-    private let emptyStateView = UILabel().then {
-        $0.text = "장바구니에 담은 상품이 없습니다."
-        $0.textAlignment = .center
-        $0.font = .fontGuide(.payModalEmptyLabel)
-        $0.textColor = .gray400
-        $0.isHidden = true
-    }
-
+    private let emptyStateView = ShoppingItemEmptyView()
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -133,10 +126,10 @@ class PayModalViewController: BaseViewController {
             $0.horizontalEdges.equalToSuperview()
             $0.bottom.equalToSuperview()
         }
-        // TODO: 이미지 추가 후 조정필요
+
         emptyStateView.snp.makeConstraints {
-            $0.center.equalToSuperview()
-            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.centerX.equalToSuperview()
+            $0.top.equalToSuperview().offset(225)
         }
 
     }
@@ -170,6 +163,7 @@ class PayModalViewController: BaseViewController {
     private func updateEmptyStateView() {
         emptyStateView.isHidden = !shoppingItemViews.isEmpty
         scrollView.isHidden = shoppingItemViews.isEmpty
+        deleteButton.isHidden = shoppingItemViews.isEmpty
     }
 
 


### PR DESCRIPTION
## 💭 작업 배경
- 장바구니에 데이터 없을 경우 화면 처리
- 라이트,다크모드 아이콘 데이터 수정

## 🌤️ PR POINT
CoreData 이후 작업할 부분은 Todo 주석으로 남겼습니다.

## 📸 스크린샷
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 라이트모드 | <img src = "https://github.com/user-attachments/assets/7eb65efd-5d8f-4b9b-b749-0925a005b233" width ="250">|
| 라이트모드 | <img src = "https://github.com/user-attachments/assets/f8482fcb-fdef-4f74-a0e8-9d8993eda174" width ="250">|
| 다크모드 | <img src = "https://github.com/user-attachments/assets/e2105c12-d3a5-42c9-aedb-ef26e72162a6" width ="250">|
| 다크모드 | <img src = "https://github.com/user-attachments/assets/9d42cac0-31a1-4191-9bbe-cc06fac516f0" width ="250">|






## 🌈 관련 이슈
- Resolved: #26 